### PR TITLE
Update analyst.py to get rid of instance name dependency

### DIFF
--- a/src/sttn/nli/analyst.py
+++ b/src/sttn/nli/analyst.py
@@ -95,16 +95,18 @@ class STTNAnalyst:
         
         # add the 'context.network' to variable in user namespace to be available in InteractiveShell's (get_ipython()) scope
         get_ipython().user_ns['_context_network'] = context.network
-        # after assigning to 'sttn_network' delete '_context_network' variable
-        prefix = "sttn_network = _context_network\ndel _context_network\n"
+        prefix = "sttn_network = _context_network\n"
         
         analysis_code = prefix + content
         context.analysis_code = content
         
         # create next cell with analysis code and run it
-        get_ipython().set_next_input(analysis_code)
+        get_ipython().set_next_input(content)
         result = get_ipython().run_cell(analysis_code)
-
+        
+        # after assigning to 'sttn_network' delete '_context_network' variable
+        del get_ipython().user_ns['_context_network']
+        
         # if the code doesn't work, fix it with LLM
         if result.error_in_exec is not None:
             fixed_code = self._network_builder.get_fixed_code(context=context, exc=result.error_in_exec)

--- a/src/sttn/nli/analyst.py
+++ b/src/sttn/nli/analyst.py
@@ -92,13 +92,20 @@ class STTNAnalyst:
 
         analysis_code = self._network_builder.get_analysis_code(context=context)
         content = analysis_code
-        prefix = "sttn_network = analyst._context.network\n"
+        
+        # add the 'context.network' to user namespace variable to be visible to InteractiveShell's (get_ipython()) scope
+        get_ipython().user_ns['_context_network'] = context.network
+        # after assigning to 'sttn_network' delete '_context_network' variable
+        prefix = "sttn_network = _context_network\ndel _context_network\n"
+        
         analysis_code = prefix + content
         context.analysis_code = content
-
+        
+        # create next cell with analysis code and run it
         get_ipython().set_next_input(analysis_code)
         result = get_ipython().run_cell(analysis_code)
 
+        # if the code doesn't work, fix it with LLM
         if result.error_in_exec is not None:
             fixed_code = self._network_builder.get_fixed_code(context=context, exc=result.error_in_exec)
             get_ipython().set_next_input(fixed_code)

--- a/src/sttn/nli/analyst.py
+++ b/src/sttn/nli/analyst.py
@@ -93,7 +93,7 @@ class STTNAnalyst:
         analysis_code = self._network_builder.get_analysis_code(context=context)
         content = analysis_code
         
-        # add the 'context.network' to user namespace variable to be visible to InteractiveShell's (get_ipython()) scope
+        # add the 'context.network' to variable in user namespace to be available in InteractiveShell's (get_ipython()) scope
         get_ipython().user_ns['_context_network'] = context.network
         # after assigning to 'sttn_network' delete '_context_network' variable
         prefix = "sttn_network = _context_network\ndel _context_network\n"


### PR DESCRIPTION
Update the STTNAnalyst class .chat() method to work properly in any scope the instance was instantiated in, and without relying on the instance's name.